### PR TITLE
improve release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,6 +4,10 @@ categories:
     label: feature
   - title: 🐛 Bug Fixes
     label: fix
+exclude-labels:
+  - 'automated-pr'
+  - 'dev-work'
+  - 're-fix-pr'
 template: |
   ## What’s Changed
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,4 @@
+filter-by-commitish: true
 categories:
   - title: 🚀 Features
     label: feature


### PR DESCRIPTION
This PR introduces these changes

- Exclude certain PRs from the changelog by using certain labels
  - `automated-pr` ( WIll be used by bots )
  - `dev-work` ( We can exclude certain development related PRs, like this one )
  - `re-fix-pr` ( We don't want what's changed to have multiple changes related to same thing )
- `filter-by-commitish` allows to distinguish what's changed based on branches